### PR TITLE
this fix prevents an problem with gmock

### DIFF
--- a/cmake/modules/FindGMock.cmake
+++ b/cmake/modules/FindGMock.cmake
@@ -91,3 +91,4 @@ find_package_handle_standard_args(GMock DEFAULT_MSG GMOCK_LIBRARIES
 
 # Mitigate build issue with Catkin
 set(GMOCK_FOUND FALSE)
+set(GMOCK_INCLUDE_DIRS ${GMOCK_SRC_DIR}/include)


### PR DESCRIPTION
When trying to build on Ubuntu 20/ROS Noetic, the GMOCK_INCLUDE_DIRS variable is not set correctly. This change allowed me to build.

https://github.com/cartographer-project/cartographer/pull/1705/files

@jccurtis 